### PR TITLE
1 module freezing bug fixed

### DIFF
--- a/src/main/java/com/bioforceanalytics/dashboard/SerialComm.java
+++ b/src/main/java/com/bioforceanalytics/dashboard/SerialComm.java
@@ -368,6 +368,12 @@ public class SerialComm {
 	
 							//Executes if the counter != temp
 							else {
+
+								if(counter == 2 && temp == 1){
+									logger.info("SECTOR COUNT misread, ignoring...");
+									continue;
+								}
+
 								//Reset the counter
 								counter = start;
 							}
@@ -1560,6 +1566,12 @@ public class SerialComm {
 						rawData.remove(rmIndex);
 						rmIndex--;
 					}
+
+					if(rawData.size() < 960){
+                        setText("Sorry, test "+ testNum +" was not recorded", statusLabel, platformType);
+                        setProgress(0, progressBar, platformType);
+                        continue;
+                    }
 
 					while(rawData.get(rmIndex) == 255) {
 						rawData.remove(rmIndex);


### PR DESCRIPTION
This looks to be one source of module lock-up.

I was able to trigger this bug by using an outdated version of the dashboard (Back when we used Revs, it was Rev-23.) If a timed test is run with a test length of 0 seconds, the module records 1 sector of flash memory usage.

Specifically before receiving raw test data, and before the "preamble" is sent, the number of sectors the module intends to send is sent by the module.

There is a slim chance of this, but if the module battery dies shortly after starting a test, the number of sectors could still be 1. The logic in waitForPreamble breaks if it receives a 1 before the first byte of the preamble. In this scenario, on the first byte of the preamble temp =1 and counter = 2, the logic would have reset the counter. Now the dashboard should ignore the duplicate 1, and continue reading the preamble.

I did not extensively test this at all. I do know that with these changes, the module will not lock up under this extremely specific circumstance, and it doesn't appear to break any other instance of waitForPreamble usage throughout SerialComm

There may be other specific instances where the inputstream contains a 1 before the beginning of a preamble. This should prevent a frozen module in that scenario.

This does not fix the problem we have seen where a module will freeze immediately after starting a test.